### PR TITLE
chore(deps): upgrade Spring Boot to 3.4.0 and Spring Cloud to 2024.0.0

### DIFF
--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -2,6 +2,7 @@ app:
   port: ${APP_PORT:8761}
   logging: debug
 
+
 server:
   port: ${app.port}
 


### PR DESCRIPTION
- Update Spring Boot version to 3.4.0
- Update Spring Cloud version to 2024.0.0
- Set Java version to 21

This upgrade ensures compatibility with latest Spring ecosystem features and security improvements.