### PR TITLE
chore(deps): update Java version to 24

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'temurin'
           cache: maven
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- Updated Java version from 21 to 24
+- Updated Spring Boot version from 3.4.0 to 3.4.4
+- Updated Spring Cloud version from 2024.0.0 to 2024.0.1
+- Updated Docker base images to use Java 24:
+  - Changed `eclipse-temurin:21-jre-alpine` to `eclipse-temurin:24-jre-alpine`
+  - Changed `maven:3-eclipse-temurin-21-alpine` to `maven:3-eclipse-temurin-24-alpine`
+- Updated GitHub Actions workflow to use Java 24
+
+## [0.0.1] - 2024-03-23
+
+### Added
+- Initial release
+- Basic Eureka Server implementation
+- Docker support
+- GitHub Actions CI/CD pipeline 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:24-jre-alpine
 
 # Instalar curl en la imagen
 RUN apk update && apk add curl

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,11 +1,11 @@
-FROM maven:3-eclipse-temurin-21-alpine AS build
+FROM maven:3-eclipse-temurin-24-alpine AS build
 ENV HOME=/usr/app
 RUN mkdir -p $HOME
 WORKDIR $HOME
 ADD . $HOME
 RUN --mount=type=cache,target=/root/.m2 mvn -f $HOME/pom.xml clean package
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:24-jre-alpine
 
 # Instalar curl en la imagen final
 RUN apk update && apk add curl

--- a/README.md
+++ b/README.md
@@ -1,3 +1,89 @@
-# PYS.eureka-service
+# PyS.eureka-service
 
 [![PyS.eureka-service CI](https://github.com/PyS-services/PyS.eureka-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/PyS-services/PyS.eureka-service/actions/workflows/maven.yml)
+
+## Description
+
+PyS.eureka-service is a Netflix Eureka Server implementation for service discovery in microservices architecture. It provides a REST-based service registry for locating services for load balancing and failover of middle-tier servers.
+
+## Features
+
+- Service registration and discovery
+- High availability and fault tolerance
+- RESTful API for service management
+- Health monitoring and status reporting
+- Self-preservation mode for network issues
+
+## Prerequisites
+
+- Java 24
+- Maven 3.6+
+- Docker (optional)
+
+## Getting Started
+
+### Local Development
+
+1. Clone the repository:
+```bash
+git clone https://github.com/PyS-services/PyS.eureka-service.git
+cd PyS.eureka-service
+```
+
+2. Build the project:
+```bash
+./mvnw clean package
+```
+
+3. Run the application:
+```bash
+java -jar target/eureka-service-0.0.1-SNAPSHOT.jar
+```
+
+### Docker
+
+Build and run using Docker:
+
+```bash
+# Build the image
+docker build -t eureka-service .
+
+# Run the container
+docker run -p 8761:8761 eureka-service
+```
+
+## Configuration
+
+The application can be configured through `application.yml` or environment variables:
+
+```yaml
+server:
+  port: 8761
+
+eureka:
+  instance:
+    hostname: localhost
+  client:
+    registerWithEureka: false
+    fetchRegistry: false
+```
+
+## API Documentation
+
+The Eureka Server provides a web interface at `http://localhost:8761` when running locally.
+
+## Contributing
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Support
+
+For support, please open an issue in the GitHub repository.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.0</version>
+		<version>3.4.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.pys.eureka</groupId>
@@ -14,8 +14,8 @@
 	<name>pys.eureka-service</name>
 	<description>pys.eureka-service</description>
 	<properties>
-		<java.version>21</java.version>
-		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<java.version>24</java.version>
+		<spring-cloud.version>2024.0.1</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
- Update Java version from 21 to 24 in pom.xml

- Update Spring Boot to 3.4.4 and Spring Cloud to 2024.0.1

- Update Docker base images to use Java 24

- Update GitHub Actions workflow to use Java 24

BREAKING CHANGE: Java 24 is now required to build and run the application