### PR TITLE
chore(deps): update project dependencies and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Updated Java version from 21 to 24
-- Updated Spring Boot version from 3.4.0 to 3.4.4
-- Updated Spring Cloud version from 2024.0.0 to 2024.0.1
-- Updated Docker base images to use Java 24:
-  - Changed `eclipse-temurin:21-jre-alpine` to `eclipse-temurin:24-jre-alpine`
-  - Changed `maven:3-eclipse-temurin-21-alpine` to `maven:3-eclipse-temurin-24-alpine`
-- Updated GitHub Actions workflow to use Java 24
+- Updated Java version from 21 to 24. (Source: `pom.xml`, `git` commit `684ee40`, `Dockerfile`, `.github/workflows/maven.yml`)
+- Updated Spring Boot version to `3.5.0`. (Source: `pom.xml`)
+- Updated Spring Cloud version to `2025.0.0`. (Source: `pom.xml`)
+- Updated Docker base images to use Java 24: (Source: `Dockerfile`, `Dockerfile.local`)
+  - `eclipse-temurin:24-jre-alpine`
+  - `maven:3-eclipse-temurin-24-alpine`
+- Updated GitHub Actions workflow to use Java 24. (Source: `.github/workflows/maven.yml`)
+
+### Added
+- Health check endpoint. (Source: `git` commit `9a43bca`)
+- CI badge to `README.md`. (Source: `git` commit `4ee7a3b`)
 
 ## [0.0.1] - 2024-03-23
 
@@ -22,4 +26,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - Basic Eureka Server implementation
 - Docker support
-- GitHub Actions CI/CD pipeline 
+- GitHub Actions CI/CD pipeline

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.4</version>
+		<version>3.5.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.pys.eureka</groupId>
@@ -15,7 +15,7 @@
 	<description>pys.eureka-service</description>
 	<properties>
 		<java.version>24</java.version>
-		<spring-cloud.version>2024.0.1</spring-cloud.version>
+		<spring-cloud.version>2025.0.0</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -40,6 +40,18 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-spring-boot-starter</artifactId>
+        </dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>
@@ -50,6 +62,13 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+            <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-bom</artifactId>
+                <version>2.16.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -2,7 +2,6 @@ app:
   port: ${APP_PORT:8761}
   logging: debug
 
-
 server:
   port: ${app.port}
 


### PR DESCRIPTION
- Updates Spring Boot to 3.5.0 and Spring Cloud to 2025.0.0.
- Adds validation, caffeine, and opentelemetry dependencies.
- Updates CHANGELOG.md to reflect these and other historical changes.
- Removes an unnecessary blank line in bootstrap.yml.