### PR TITLE
chore(release): bump version and update dependencies (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2] - 2025-06-29
+
 ### Changed
 - Updated Java version from 21 to 24. (Source: `pom.xml`, `git` commit `684ee40`)
 - Updated Spring Boot version to `3.5.3`. (Source: `pom.xml`)
 - Updated Spring Cloud version to `2025.0.0`. (Source: `pom.xml`)
-- Updated OpenTelemetry version to `2.16.0`. (Source: `pom.xml`)
+- Updated OpenTelemetry version to `2.17.0`. (Source: `pom.xml`)
 - Updated project dependencies and documentation. (Source: `git` commit `c2252e2`)
 - Added Caffeine cache dependency. (Source: `pom.xml`)
 - Added OpenTelemetry Spring Boot Starter. (Source: `pom.xml`)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ PyS.eureka-service is a Netflix Eureka Server implementation for service discove
 - Spring Boot 3.5.3
 - Spring Cloud 2025.0.0
 - Spring Cloud Netflix Eureka Server
-- OpenTelemetry Spring Boot Starter 2.16.0
+- OpenTelemetry Spring Boot Starter 2.17.0
 - Caffeine Cache
 
 ## Getting Started

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pys.eureka</groupId>
 	<artifactId>eureka-service</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<name>pys.eureka-service</name>
 	<description>pys.eureka-service</description>
 	<properties>
@@ -65,7 +65,7 @@
             <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>
                 <artifactId>opentelemetry-instrumentation-bom</artifactId>
-                <version>2.16.0</version>
+                <version>2.17.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Descripción
Este Pull Request actualiza la versión de la aplicación y las dependencias de OpenTelemetry, además de sincronizar la documentación relevante.

## Cambios realizados
- [x] **Actualización de la versión de la aplicación:**
    - `pom.xml`: La versión de la aplicación se ha actualizado de `0.0.1-SNAPSHOT` a `0.0.2-SNAPSHOT`.
- [x] **Actualización de la dependencia OpenTelemetry:**
    - `pom.xml`: La versión de OpenTelemetry se ha actualizado de `2.16.0` a `2.17.0`.
    - `README.md`: La versión de OpenTelemetry se ha actualizado a `2.17.0` en la sección de dependencias.
    - `CHANGELOG.md`: La versión de OpenTelemetry se ha actualizado a `2.17.0` dentro de la nueva sección de la versión `0.0.2`.
- [x] **Actualización del Changelog:**
    - `CHANGELOG.md`: La sección `[Unreleased]` anterior ha sido renombrada a `[0.0.2] - 2025-06-29`, y se ha añadido una nueva sección `[Unreleased]` en la parte superior.

## Impacto potencial
- [ ] Este PR implica una actualización de versión y de dependencias. Se espera que los cambios mejoren la estabilidad y potencialmente introduzcan nuevas funcionalidades de las dependencias actualizadas.
- [ ] No se requieren migraciones de base de datos.
- [ ] No hay cambios en las variables de entorno.

## Verificación
- [x] El proyecto se ha construido localmente (`./mvnw clean package`).
- [ ] Se han ejecutado las pruebas existentes (si aplica).
- [ ] Se ha verificado que la aplicación se inicia correctamente.

## Notas adicionales
- [ ] Este PR resuelve la issue #20.
